### PR TITLE
Add theme picker and background upload

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,17 @@ This is a basic HTML starter project you can build on however you like. No need 
 
 _Last updated: 28 Feb 2023_
 
+## Características recientes
+
+- Selección de tema (claro, oscuro, azul o verde) desde el menú superior.
+- Posibilidad de subir una imagen para usarla como fondo y que se mantiene guardada.
+- Sonido "Start" reproducido cada vez que comienza una nueva etapa.
+
+## Librerías utilizadas
+
+- [Bootstrap 5](https://getbootstrap.com) para estilos y componentes responsivos.
+- [Font Awesome](https://fontawesome.com) para iconos.
+
 ## What's in this project?
 
 ← `README.md`: That's this file, where you can tell people what your cool website does and how you built it.

--- a/app.js
+++ b/app.js
@@ -21,6 +21,9 @@ class EssayTimer {
 
         // DOM Elements
         this.themeToggleBtn = document.getElementById('theme-toggle-btn');
+        this.themeSelect = document.getElementById('theme-select');
+        this.backgroundInput = document.getElementById('background-input');
+        this.clearBgBtn = document.getElementById('clear-bg-btn');
         this.sessionTimeEl = document.getElementById('session-time'); // NUEVO
         this.totalTimeEl = document.getElementById('total-time');
         // ... (resto de elementos DOM sin cambios)
@@ -38,6 +41,7 @@ class EssayTimer {
         this.addStageBtn = document.getElementById('add-stage-btn');
         this.essayNotes = document.getElementById('essay-notes');
         this.notificationSound = document.getElementById('notification-sound');
+        this.startSound = document.getElementById('start-sound');
 
         // State
         this.stages = [];
@@ -61,6 +65,7 @@ class EssayTimer {
         this.loadAndCheckDailySession(); // NUEVO
         this.reset();
         this.loadTheme();
+        this.loadBackgroundImage();
     }
     
     // --- NUEVAS FUNCIONALIDADES ---
@@ -146,6 +151,7 @@ class EssayTimer {
         if (stage && !stage.isExtra) {
             this.timeLeftInStage = stage.duration * 60;
         }
+        this.playStartSound();
     }
 
     // El resto del archivo app.js permanece igual...
@@ -226,6 +232,9 @@ class EssayTimer {
     }
     attachEventListeners() {
         this.themeToggleBtn.addEventListener('click', () => this.toggleTheme());
+        this.themeSelect.addEventListener('change', () => this.setTheme(this.themeSelect.value));
+        this.backgroundInput.addEventListener('change', (e) => this.handleBackgroundUpload(e));
+        this.clearBgBtn.addEventListener('click', () => this.clearBackgroundImage());
         this.startBtn.addEventListener('click', () => this.start());
         this.pauseBtn.addEventListener('click', () => this.pause());
         this.resetBtn.addEventListener('click', () => this.reset(true));
@@ -247,17 +256,50 @@ class EssayTimer {
     }
     loadTheme() {
         const theme = localStorage.getItem('essayTimer_theme') || 'light';
-        document.body.className = theme === 'dark' ? 'dark-mode' : '';
-        this.themeToggleBtn.textContent = theme === 'dark' ? '☀️' : '🌙';
+        this.setTheme(theme);
     }
     toggleTheme() {
-        const isDark = document.body.classList.toggle('dark-mode');
-        localStorage.setItem('essayTimer_theme', isDark ? 'dark' : 'light');
-        this.themeToggleBtn.textContent = isDark ? '☀️' : '🌙';
+        const current = localStorage.getItem('essayTimer_theme') || 'light';
+        const next = current === 'dark' ? 'light' : 'dark';
+        this.setTheme(next);
+    }
+    setTheme(theme) {
+        document.body.className = '';
+        if (theme !== 'light') document.body.classList.add(`${theme}-mode`);
+        localStorage.setItem('essayTimer_theme', theme);
+        this.themeToggleBtn.innerHTML = theme === 'dark' ? '<i class="fa-solid fa-sun"></i>' : '<i class="fa-solid fa-moon"></i>';
+        if (this.themeSelect) this.themeSelect.value = theme;
+    }
+    loadBackgroundImage() {
+        const img = localStorage.getItem('essayTimer_bgImage');
+        if (img) {
+            document.body.style.backgroundImage = `url(${img})`;
+        }
+    }
+    handleBackgroundUpload(e) {
+        const file = e.target.files[0];
+        if (!file) return;
+        const reader = new FileReader();
+        reader.onload = () => {
+            const data = reader.result;
+            localStorage.setItem('essayTimer_bgImage', data);
+            document.body.style.backgroundImage = `url(${data})`;
+        };
+        reader.readAsDataURL(file);
+    }
+    clearBackgroundImage() {
+        localStorage.removeItem('essayTimer_bgImage');
+        document.body.style.backgroundImage = 'none';
+        this.backgroundInput.value = '';
     }
     playNotification() {
         this.notificationSound.currentTime = 0;
         this.notificationSound.play().catch(e => console.log("La reproducción automática fue bloqueada."));
+    }
+    playStartSound() {
+        if (!this.startSound) return;
+        this.startSound.currentTime = 0;
+        this.startSound.play().catch(e => console.log('La reproducción automática fue bloqueada.'));
     }
     loadTemplates() {
         let templates = JSON.parse(localStorage.getItem('essayTimer_templates')) || {};

--- a/index.html
+++ b/index.html
@@ -5,10 +5,22 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Advanced Essay Timer</title>
     <link rel="stylesheet" href="style.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
 </head>
 <body>
-    <button id="theme-toggle-btn">🌙</button>
-
+    <button id="theme-toggle-btn" class="btn btn-secondary"><i class="fa-solid fa-moon"></i></button>
+    <div id="theme-settings" class="theme-settings">
+        <select id="theme-select" class="form-select form-select-sm">
+            <option value="light">Claro</option>
+            <option value="dark">Oscuro</option>
+            <option value="blue">Azul</option>
+            <option value="green">Verde</option>
+        </select>
+        <input type="file" id="background-input" class="form-control form-control-sm" accept="image/*">
+        <button id="clear-bg-btn" class="btn btn-sm btn-outline-secondary">Quitar Fondo</button>
+    </div>
+    <div class="container main-container">
     <h1>Advanced Essay Timer 📝</h1>
 
     <div id="session-tracker">
@@ -16,23 +28,23 @@
     </div>
 
     <div id="essay-manager" class="manager-section">
-        <input type="text" id="essay-name-input" placeholder="Nombre del Ensayo">
-        <button id="new-essay-btn">Empezar Nuevo</button>
+        <input type="text" id="essay-name-input" class="form-control" placeholder="Nombre del Ensayo">
+        <button id="new-essay-btn" class="btn btn-primary">Empezar Nuevo</button>
         <span>O</span>
-        <select id="saved-essays-select">
+        <select id="saved-essays-select" class="form-select">
             <option value="">Cargar Ensayo Guardado</option>
         </select>
-        <button id="delete-essay-btn" disabled>Borrar</button>
+        <button id="delete-essay-btn" class="btn btn-danger" disabled>Borrar</button>
     </div>
 
     <div id="template-manager" class="manager-section">
-        <select id="template-select">
+        <select id="template-select" class="form-select">
             <option value="default">Plantilla por Defecto</option>
         </select>
-        <div id="template-controls">
-            <button id="edit-template-btn">Editar Plantilla</button>
-            <button id="save-template-btn" class="edit-mode-only">Guardar Cambios</button>
-            <button id="cancel-edit-btn" class="edit-mode-only">Cancelar</button>
+        <div id="template-controls" class="mt-2">
+            <button id="edit-template-btn" class="btn btn-secondary">Editar Plantilla</button>
+            <button id="save-template-btn" class="btn btn-success edit-mode-only">Guardar Cambios</button>
+            <button id="cancel-edit-btn" class="btn btn-outline-secondary edit-mode-only">Cancelar</button>
         </div>
     </div>
 
@@ -47,17 +59,20 @@
         </div>
     
     <div id="add-stage-container" class="edit-mode-only">
-        <button id="add-stage-btn">+ Añadir Etapa</button>
+        <button id="add-stage-btn" class="btn btn-primary">+ Añadir Etapa</button>
     </div>
 
-    <div id="controls">
-        <button id="start-btn" disabled>Empezar</button>
-        <button id="pause-btn" disabled>Pausar</button>
-        <button id="reset-btn" disabled>Reiniciar</button>
+    <div id="controls" class="my-3">
+        <button id="start-btn" class="btn btn-success" disabled>Empezar</button>
+        <button id="pause-btn" class="btn btn-warning" disabled>Pausar</button>
+        <button id="reset-btn" class="btn btn-danger" disabled>Reiniciar</button>
     </div>
     
     <audio id="notification-sound" src="https://www.soundjay.com/buttons/sounds/button-16.mp3" preload="auto"></audio>
+    <audio id="start-sound" src="Sounds/Start.mp3" preload="auto"></audio>
 
+    </div>
     <script src="app.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
 </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -1,3 +1,5 @@
+@import url('https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;600&display=swap');
+
 /* Estilos Base (sin cambios) */
 :root {
     --bg-color: #f4f4f9;
@@ -21,13 +23,40 @@ body.dark-mode {
     --primary-hover: #0b5ed7;
 }
 
-body { 
-    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif; 
-    margin: 20px; 
-    text-align: center; 
-    background-color: var(--bg-color); 
+body.blue-mode {
+    --bg-color: #e6f2ff;
+    --text-color: #034694;
+    --card-bg-color: #ffffff;
+    --border-color: #cce5ff;
+    --primary-color: #0d6efd;
+    --primary-hover: #0b5ed7;
+}
+
+body.green-mode {
+    --bg-color: #e7f6e7;
+    --text-color: #065f46;
+    --card-bg-color: #ffffff;
+    --border-color: #b2dfdb;
+    --primary-color: #198754;
+    --primary-hover: #157347;
+}
+
+body {
+    font-family: 'Poppins', -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+    margin: 0;
+    background-color: var(--bg-color);
+    background-size: cover;
+    background-repeat: no-repeat;
+    background-position: center;
     color: var(--text-color);
     transition: background-color 0.3s, color 0.3s;
+}
+
+.main-container {
+    max-width: 900px;
+    margin: 20px auto;
+    padding: 0 20px;
+    text-align: center;
 }
 
 h1, h2 { margin: 0.5em 0; }
@@ -48,6 +77,14 @@ textarea { width: 90%; max-width: 800px; min-height: 80px; margin-top: 10px; }
 #total-time { font-size: 1.5em; margin-top: 20px; font-weight: bold; }
 .manager-section { background-color: var(--card-bg-color); padding: 15px; border-radius: 8px; box-shadow: 0 2px 4px rgba(0,0,0,0.1); max-width: 800px; margin: 20px auto; display: flex; flex-wrap: wrap; justify-content: center; align-items: center; gap: 10px; }
 #theme-toggle-btn { position: fixed; top: 15px; right: 15px; z-index: 100; }
+#theme-settings {
+    position: fixed;
+    top: 15px;
+    left: 15px;
+    z-index: 100;
+    display: flex;
+    gap: 5px;
+}
 
 /* NUEVO: Estilos para el Marcador de Sesión */
 #session-tracker {
@@ -101,4 +138,13 @@ textarea { width: 90%; max-width: 800px; min-height: 80px; margin-top: 10px; }
 
 #add-stage-container {
     margin-top: 10px;
+}
+
+#notes-section {
+    background-color: var(--card-bg-color);
+    padding: 15px;
+    border-radius: 8px;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+    max-width: 800px;
+    margin: 20px auto;
 }


### PR DESCRIPTION
## Summary
- add dropdown to choose between several color themes
- allow uploading a custom background image and clearing it
- store chosen theme and background in localStorage
- play local `Start.mp3` sound when a stage begins
- document new features in README

## Testing
- `node -v`


------
https://chatgpt.com/codex/tasks/task_e_687d5ea886388322a625041551afa9c4