### PR TITLE
Add pomodoro tracker

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,6 +30,10 @@
             <strong>Tiempo de Foco Hoy:</strong> <span id="session-time">00:00:00</span>
         </div>
 
+        <div id="pomodoro-counter" class="my-3">
+            <strong>Pomodoros completados:</strong> <span id="pomodoro-count">0</span>
+        </div>
+
         <div id="essay-manager" class="manager-section mb-4">
             <div class="row g-2 align-items-center">
                 <div class="col-auto">

--- a/style.css
+++ b/style.css
@@ -194,6 +194,18 @@ textarea {
     box-shadow: 0 2px 4px rgba(0,0,0,0.1);
 }
 
+#pomodoro-counter {
+    background-color: var(--card-bg-color);
+    color: var(--text-color);
+    padding: 10px 20px;
+    border-radius: 8px;
+    font-size: 1.1em;
+    font-weight: bold;
+    margin: 10px auto;
+    max-width: fit-content;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+}
+
 /* Modo Edición */
 .delete-stage-btn {
     position: absolute;


### PR DESCRIPTION
## Summary
- show completed pomodoros in the UI
- style pomodoro counter like session tracker
- add Pomodoro 30/5 template with long break
- update templates loader
- keep page title updated with remaining time
- count finished pomodoros

## Testing
- `node -e "require('./app.js')"` *(fails: document is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_6880f126dda883229af6fd524381cab0