### PR TITLE
Add floating stage overlay and visibility handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,11 @@ _Last updated: 28 Feb 2023_
 - Selección de tema (claro, oscuro, azul o verde) desde el menú superior.
 - Posibilidad de subir una imagen para usarla como fondo y que se mantiene guardada.
 - Sonido "Start" reproducido cada vez que comienza una nueva etapa.
+- Cuando la pestaña del navegador queda oculta, un pequeño overlay muestra la etapa actual y el tiempo restante.
+
+## Overlay flotante
+
+Al cambiar de pestaña, el navegador oculta la página y puede ser fácil perder el progreso. Ahora se crea un contenedor flotante que se muestra mientras la página está oculta e indica en todo momento la etapa actual del temporizador y cuánto tiempo queda. Al volver a la pestaña, el overlay desaparece automáticamente.
 
 ## Librerías utilizadas
 

--- a/app.js
+++ b/app.js
@@ -86,6 +86,7 @@ class EssayTimer {
         this.updatePomodoroDisplay();
         this.loadTheme();
         this.loadBackgroundImage();
+        this.setupVisibilityHandler();
     }
     
     // --- NUEVAS FUNCIONALIDADES ---
@@ -343,6 +344,43 @@ class EssayTimer {
         localStorage.removeItem('essayTimer_bgImage');
         document.body.style.backgroundImage = 'none';
         this.backgroundInput.value = '';
+    }
+
+    setupVisibilityHandler() {
+        const overlay = document.getElementById('floating-stage');
+        if (!overlay) return;
+
+        const asistenteContainer = document.getElementById('asistente-container');
+        const assistantToggleBtn = document.getElementById('assistant-toggle-btn');
+        let interval;
+
+        const updateOverlay = () => {
+            const stage = this.stages[this.currentStageIndex];
+            if (!stage) return;
+            const time = stage.isExtra ? this.extraTime : this.timeLeftInStage;
+            overlay.textContent = `${stage.label}: ${this.formatTime(time)}`;
+        };
+
+        document.addEventListener('visibilitychange', () => {
+            if (document.hidden) {
+                updateOverlay();
+                overlay.style.display = 'block';
+                interval = setInterval(updateOverlay, 1000);
+
+                if (asistenteContainer && asistenteContainer.style.display === 'none') {
+                    asistenteContainer.style.display = 'flex';
+                    if (assistantToggleBtn) assistantToggleBtn.style.display = 'none';
+                }
+
+                const stage = this.stages[this.currentStageIndex];
+                if (window.asistenteDecir && stage) {
+                    window.asistenteDecir(`Etapa actual: ${stage.label}`);
+                }
+            } else {
+                overlay.style.display = 'none';
+                clearInterval(interval);
+            }
+        });
     }
     playNotification() {
         this.notificationSound.currentTime = 0;

--- a/assistant.js
+++ b/assistant.js
@@ -56,6 +56,18 @@ function asistenteCambiarFase(nuevaFase) {
   asistenteIntervaloDialogo = setInterval(asistenteMostrarSiguienteDialogo, 8000);
 }
 
+// Mostrar mensaje personalizado inmediatamente
+function asistenteDecir(mensaje) {
+  if (!asistenteContainer) return;
+  asistenteContainer.style.display = 'flex';
+  if (asistenteToggleBtn) asistenteToggleBtn.style.display = 'none';
+  clearInterval(asistenteIntervaloDialogo);
+  asistenteTextoDialogo.innerText = mensaje;
+  asistenteBurbuja.style.opacity = '1';
+}
+
+window.asistenteDecir = asistenteDecir;
+
 // Drag helpers
 const startDrag = (clientX, clientY) => {
   isDragging = true;

--- a/index.html
+++ b/index.html
@@ -213,6 +213,8 @@
     </div>
   </div>
 
+  <div id="floating-stage"></div>
+
   <!-- Scripts -->
   <script src="html5up-massively/assets/js/jquery.min.js"></script>
   <script src="html5up-massively/assets/js/jquery.scrollex.min.js"></script>

--- a/style.css
+++ b/style.css
@@ -284,6 +284,19 @@ textarea {
   cursor: move;
 }
 
+#floating-stage {
+  position: fixed;
+  bottom: 15px;
+  left: 15px;
+  padding: 8px 12px;
+  background: rgba(0,0,0,0.8);
+  color: #fff;
+  border-radius: 6px;
+  font-size: 14px;
+  z-index: 10001;
+  display: none;
+}
+
 #personaje-img {
   height: 280px;
   animation: asistente-bob-and-sway 6s ease-in-out infinite;


### PR DESCRIPTION
## Summary
- show a floating overlay when the page is hidden
- display stage info inside the overlay with visibility handler
- keep assistant visible when overlay shows and add `asistenteDecir`
- document new overlay feature in README

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6883aac1edb083228161355e6ed96383