### PR TITLE
Remove self-call from start script

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -6,6 +6,3 @@ cd "$DIR"
 
 # Launch the built‑in Python server
 python3 -m http.server "$PORT"
-
-chmod +x start.sh
-./start.sh


### PR DESCRIPTION
## Summary
- clean up `start.sh`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6883aac3c6f88322a7fd77c28c3461fa