### PR TITLE
Implement active stage animation

### DIFF
--- a/app.js
+++ b/app.js
@@ -64,6 +64,7 @@ class EssayTimer {
         // State
         this.stages = [];
         this.stageElements = {};
+        this.previousStageId = null;
         this.currentStageIndex = 0;
         this.isPaused = true;
         this.isRunning = false;
@@ -198,6 +199,7 @@ class EssayTimer {
         if (stage && !stage.isExtra) {
             this.timeLeftInStage = stage.duration * 60;
         }
+        this.highlightCurrentStage();
         this.playStartSound();
         this.updatePageTitle();
     }
@@ -258,6 +260,7 @@ class EssayTimer {
             `;
             this.container.appendChild(timerContainer);
             this.stageElements[stage.id] = {
+                container: timerContainer,
                 input: timerContainer.querySelector(`input[data-id="${stage.id}"]`),
                 display: timerContainer.querySelector(`div[data-id="${stage.id}-display"]`),
                 progress: timerContainer.querySelector(`div[data-id="${stage.id}-progress"]`),
@@ -277,6 +280,7 @@ class EssayTimer {
             }
         });
         this.updateAllDisplays();
+        this.highlightCurrentStage();
     }
     attachEventListeners() {
         this.themeToggleBtn.addEventListener('click', () => this.toggleTheme());
@@ -530,6 +534,17 @@ class EssayTimer {
         let totalSeconds = activeStages.reduce((acc, stage) => acc + (stage.duration * 60), 0);
         this.totalTimeEl.textContent = `Tiempo Total: ${this.formatTime(totalSeconds)}`;
     }
+
+    highlightCurrentStage() {
+        if (this.previousStageId && this.stageElements[this.previousStageId]?.container) {
+            this.stageElements[this.previousStageId].container.classList.remove('active-stage');
+        }
+        const current = this.stages[this.currentStageIndex];
+        if (current && this.stageElements[current.id]?.container) {
+            this.stageElements[current.id].container.classList.add('active-stage');
+            this.previousStageId = current.id;
+        }
+    }
     updateAllDisplays() {
         this.stages.forEach((stage, index) => {
             const elements = this.stageElements[stage.id];
@@ -603,6 +618,7 @@ class EssayTimer {
             this.loadTemplate(this.templateSelect.value);
         }
         this.updateAllDisplays();
+        this.highlightCurrentStage();
         this.updatePageTitle();
         this.startBtn.textContent = 'Empezar';
         this.startBtn.disabled = !this.currentEssayName;

--- a/style.css
+++ b/style.css
@@ -92,6 +92,17 @@ h1, h2 { margin: 0.5em 0; }
   transition: background-color 0.3s, border-color 0.3s;
 }
 
+@keyframes stagePulse {
+  0%   { transform: scale(1); }
+  50%  { transform: scale(1.05); }
+  100% { transform: scale(1); }
+}
+
+.active-stage {
+  border: 2px solid var(--primary-color);
+  animation: stagePulse 0.5s ease;
+}
+
 .timer-display {
   font-size: 2em;
   margin-top: 10px;


### PR DESCRIPTION
## Summary
- animate current stage with `stagePulse` effect
- record timer container in `stageElements`
- switch active stage container when stage changes
- keep highlight updated on reset and re-render

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68841d6768408322bc391337bbe59512