### PR TITLE
Add nickname login overlay

### DIFF
--- a/app.js
+++ b/app.js
@@ -26,8 +26,7 @@ const pomodoro30Template = {
     ]
 };
 
-const db = new LocalDB('essayTimer');
-
+let db;
 class EssayTimer {
     constructor(containerId) {
         this.container = document.getElementById(containerId);
@@ -631,10 +630,34 @@ class EssayTimer {
     }
 }
 
-if (document.readyState === 'loading') {
-    document.addEventListener('DOMContentLoaded', () => {
-        new EssayTimer('timers-container');
-    });
-} else {
-    new EssayTimer('timers-container');
+let appInstance;
+
+function startApp(nickname) {
+    db = new LocalDB('essayTimer_' + nickname);
+    appInstance = new EssayTimer('timers-container');
 }
+
+function showLogin() {
+    const overlay = document.getElementById('login-overlay');
+    const input = document.getElementById('nickname-input');
+    const btn = document.getElementById('login-btn');
+    const tryStart = () => {
+        const nick = input.value.trim();
+        if (!nick) return;
+        localStorage.setItem('currentNickname', nick);
+        overlay.classList.add('hidden');
+        startApp(nick);
+    };
+    overlay.classList.remove('hidden');
+    btn.addEventListener('click', tryStart);
+    input.addEventListener('keyup', (e) => { if (e.key === 'Enter') tryStart(); });
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+    const stored = localStorage.getItem('currentNickname');
+    if (stored) {
+        startApp(stored);
+    } else {
+        showLogin();
+    }
+});

--- a/index.html
+++ b/index.html
@@ -214,6 +214,13 @@
   </div>
 
   <div id="floating-stage"></div>
+  <div id="login-overlay" class="hidden">
+    <div id="login-box">
+      <h2>Bienvenido</h2>
+      <input type="text" id="nickname-input" class="form-control" placeholder="Tu nickname"/>
+      <button id="login-btn" class="btn btn-primary mt-2">Entrar</button>
+    </div>
+  </div>
 
   <!-- Scripts -->
   <script src="html5up-massively/assets/js/jquery.min.js"></script>

--- a/style.css
+++ b/style.css
@@ -457,3 +457,30 @@ textarea {
     margin-bottom: 60px;
   }
 }
+
+/* User login overlay */
+#login-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0,0,0,0.8);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 20000;
+}
+#login-overlay.hidden {
+  display: none;
+}
+#login-box {
+  background: var(--card-bg-color);
+  color: var(--text-color);
+  padding: 20px;
+  border-radius: 8px;
+  text-align: center;
+}
+#login-box input {
+  margin-bottom: 10px;
+}


### PR DESCRIPTION
## Summary
- prompt user for nickname on first visit and store it in localStorage
- create user-specific LocalDB prefix so each user gets their own data
- display a login overlay and basic styles

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68842fc8d67c832284726423b5229a57