### PR TITLE
feat: floating todo list with completion timestamps and scroll

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ This is a basic HTML starter project you can build on however you like. No need 
 * Sonido "Start" reproducido cada vez que comienza una nueva etapa.
 * Cuando la pestaña del navegador queda oculta, un pequeño overlay muestra la etapa actual y el tiempo restante.
 * Si el asistente estaba oculto, se mostrará temporalmente para anunciar la etapa.
+* Lista de tareas en ventana flotante con fecha y prioridad. Las tareas pueden arrastrarse, ordenarse por fecha o prioridad y marcarse como completadas, registrando la hora de finalización. Las prioridades se muestran con colores distintivos y la ventana permite desplazarse para manejar listas largas.
 
 ## Overlay flotante
 

--- a/index.html
+++ b/index.html
@@ -64,6 +64,9 @@
           <button id="assistant-toggle-btn" class="btn btn-secondary" title="Mostrar/Ocultar Asistente">
             <i class="fa-solid fa-comments"></i>
           </button>
+          <button id="todo-toggle-btn" class="btn btn-secondary" title="Mostrar/Ocultar Tareas">
+            <i class="fa-solid fa-list-check"></i>
+          </button>
 
           <!-- Theme settings -->
           <div id="theme-settings" class="theme-settings">
@@ -125,6 +128,33 @@
           <div id="notes-section" class="mb-4">
             <h2>Notas del Ensayo</h2>
             <textarea id="essay-notes" class="form-control" rows="5" placeholder="Escribe tus ideas, enlaces o recordatorios aquí..."></textarea>
+          </div>
+
+          <div id="todo-section" class="text-start">
+            <h2>Lista de Tareas</h2>
+            <form id="todo-form" class="row g-2 align-items-center">
+              <div class="col-sm">
+                <input type="text" id="todo-input" class="form-control" placeholder="Nueva tarea" />
+              </div>
+              <div class="col-auto">
+                <input type="date" id="todo-date" class="form-control" />
+              </div>
+              <div class="col-auto">
+                <select id="todo-priority" class="form-select">
+                  <option value="low">Baja</option>
+                  <option value="medium">Media</option>
+                  <option value="high">Alta</option>
+                </select>
+              </div>
+              <div class="col-auto">
+                <button type="submit" class="btn btn-primary">Agregar</button>
+              </div>
+            </form>
+            <div class="my-2">
+              <button id="sort-date" class="btn btn-sm btn-outline-secondary">Ordenar por Fecha</button>
+              <button id="sort-priority" class="btn btn-sm btn-outline-secondary">Ordenar por Prioridad</button>
+            </div>
+            <ul id="todo-list" class="list-unstyled"></ul>
           </div>
 
           <div id="total-time" class="mb-3"><strong>Tiempo Total:</strong> <span>00:00</span></div>
@@ -241,6 +271,7 @@
 
   <script src="db.js"></script>
   <script src="app.js"></script>
+  <script src="todo.js"></script>
   <script src="assistant.js"></script>
 
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>

--- a/style.css
+++ b/style.css
@@ -514,3 +514,79 @@ textarea {
 #login-box input {
   margin-bottom: 10px;
 }
+
+/* ==========================
+   TODO LIST
+   ========================== */
+#todo-section {
+  position: fixed;
+  top: 1rem;
+  right: 1rem;
+  width: 300px;
+  margin: 0;
+  background: var(--card-bg-color);
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  padding: 1rem;
+  box-shadow: 0 4px 8px rgba(0,0,0,0.2);
+  z-index: 1000;
+  max-height: 70vh;
+  overflow-y: auto;
+}
+#todo-list {
+  list-style: none;
+  padding: 0;
+}
+.todo-item {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  align-items: center;
+  padding: 8px;
+  margin: 4px 0;
+  border: 1px solid var(--border-color);
+  border-radius: 5px;
+  background-color: var(--card-bg-color);
+  cursor: move;
+}
+.todo-item.done .todo-text {
+  text-decoration: line-through;
+}
+.todo-item.dragging {
+  opacity: 0.5;
+}
+.todo-text {
+  flex: 1;
+}
+.todo-priority.high {
+  color: var(--danger-color);
+}
+.todo-priority.medium {
+  color: #fd7e14;
+}
+.todo-priority.low {
+  color: #198754;
+}
+
+.priority-high {
+  border-left: 4px solid var(--danger-color);
+  background-color: rgba(220,53,69,0.1);
+}
+.priority-medium {
+  border-left: 4px solid #fd7e14;
+  background-color: rgba(253,126,20,0.1);
+}
+.priority-low {
+  border-left: 4px solid #198754;
+  background-color: rgba(25,135,84,0.1);
+}
+
+.completed-info {
+  width: 100%;
+  font-size: 0.8em;
+  color: #6c757d;
+}
+
+.todo-item .form-check-input {
+  margin-right: 0.5rem;
+}

--- a/todo.js
+++ b/todo.js
@@ -1,0 +1,192 @@
+class TodoApp {
+  constructor() {
+    this.db = new LocalDB('todo');
+    this.tasks = this.db.get('tasks') || [];
+    this.lastCompletedTime = this.db.get('lastCompletedTime');
+    this.listEl = document.getElementById('todo-list');
+    this.form = document.getElementById('todo-form');
+    this.inputEl = document.getElementById('todo-input');
+    this.dateEl = document.getElementById('todo-date');
+    this.priorityEl = document.getElementById('todo-priority');
+    this.sortDateBtn = document.getElementById('sort-date');
+    this.sortPriorityBtn = document.getElementById('sort-priority');
+    this.section = document.getElementById('todo-section');
+    this.toggleBtn = document.getElementById('todo-toggle-btn');
+
+    if (this.form) {
+      this.form.addEventListener('submit', (e) => {
+        e.preventDefault();
+        this.addTask();
+      });
+    }
+
+    if (this.sortDateBtn) {
+      this.sortDateBtn.addEventListener('click', () => this.sortByDate());
+    }
+    if (this.sortPriorityBtn) {
+      this.sortPriorityBtn.addEventListener('click', () => this.sortByPriority());
+    }
+
+    if (this.listEl) {
+      this.listEl.addEventListener('dragover', (e) => this.onDragOver(e));
+    }
+
+    if (this.toggleBtn && this.section) {
+      this.toggleBtn.addEventListener('click', () => {
+        this.section.classList.toggle('d-none');
+      });
+    }
+
+    this.render();
+  }
+
+  addTask() {
+    const text = this.inputEl.value.trim();
+    const date = this.dateEl.value;
+    const priority = this.priorityEl.value;
+    if (!text) return;
+    const task = { id: Date.now(), text, date, priority, completed: false };
+    this.tasks.push(task);
+    this.save();
+    this.form.reset();
+    this.render();
+  }
+
+  render() {
+    if (!this.listEl) return;
+    this.listEl.innerHTML = '';
+    this.tasks.forEach((task) => {
+      const li = document.createElement('li');
+      li.className = `todo-item priority-${task.priority} ${task.completed ? 'done' : ''}`;
+      li.draggable = true;
+      li.dataset.id = task.id;
+
+      const checkbox = document.createElement('input');
+      checkbox.type = 'checkbox';
+      checkbox.className = 'form-check-input';
+      checkbox.checked = !!task.completed;
+      checkbox.addEventListener('change', () => this.toggleComplete(task.id));
+
+      const textSpan = document.createElement('span');
+      textSpan.className = 'todo-text';
+      textSpan.textContent = task.text;
+
+      const dateSpan = document.createElement('span');
+      dateSpan.className = 'todo-date';
+      dateSpan.textContent = task.date;
+
+      const prioritySpan = document.createElement('span');
+      prioritySpan.className = `todo-priority ${task.priority}`;
+      prioritySpan.textContent = this.labelPriority(task.priority);
+
+      const infoSpan = document.createElement('span');
+      infoSpan.className = 'completed-info';
+      if (task.completed && task.completedAt) {
+        infoSpan.textContent = `Completada a las ${task.completedAt}`;
+        if (task.timeSinceLast) {
+          infoSpan.textContent += ` (+${task.timeSinceLast})`;
+        }
+      }
+
+      li.append(checkbox, textSpan, dateSpan, prioritySpan, infoSpan);
+
+      li.addEventListener('dragstart', () => li.classList.add('dragging'));
+      li.addEventListener('dragend', () => {
+        li.classList.remove('dragging');
+        this.updateOrderFromDOM();
+      });
+      this.listEl.appendChild(li);
+    });
+  }
+
+  labelPriority(p) {
+    switch (p) {
+      case 'high': return 'Alta';
+      case 'medium': return 'Media';
+      default: return 'Baja';
+    }
+  }
+
+  onDragOver(e) {
+    e.preventDefault();
+    const afterElement = this.getDragAfterElement(e.clientY);
+    const dragging = this.listEl.querySelector('.dragging');
+    if (!dragging) return;
+    if (afterElement == null) {
+      this.listEl.appendChild(dragging);
+    } else {
+      this.listEl.insertBefore(dragging, afterElement);
+    }
+  }
+
+  getDragAfterElement(y) {
+    const elements = [...this.listEl.querySelectorAll('.todo-item:not(.dragging)')];
+    return elements.reduce((closest, child) => {
+      const box = child.getBoundingClientRect();
+      const offset = y - box.top - box.height / 2;
+      if (offset < 0 && offset > closest.offset) {
+        return { offset, element: child };
+      } else {
+        return closest;
+      }
+    }, { offset: Number.NEGATIVE_INFINITY }).element;
+  }
+
+  updateOrderFromDOM() {
+    const order = [...this.listEl.children].map(li => Number(li.dataset.id));
+    this.tasks.sort((a, b) => order.indexOf(a.id) - order.indexOf(b.id));
+    this.save();
+  }
+
+  sortByDate() {
+    this.tasks.sort((a, b) => (a.date || '').localeCompare(b.date || ''));
+    this.save();
+    this.render();
+  }
+
+  sortByPriority() {
+    const rank = { high: 0, medium: 1, low: 2 };
+    this.tasks.sort((a, b) => rank[a.priority] - rank[b.priority]);
+    this.save();
+    this.render();
+  }
+
+  toggleComplete(id) {
+    const task = this.tasks.find(t => t.id === id);
+    if (!task) return;
+    task.completed = !task.completed;
+    if (task.completed) {
+      const now = new Date();
+      task.completedAt = now.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+      if (this.lastCompletedTime) {
+        const diff = now - new Date(this.lastCompletedTime);
+        task.timeSinceLast = this.formatDuration(diff);
+      }
+      this.lastCompletedTime = now.toISOString();
+    } else {
+      delete task.completedAt;
+      delete task.timeSinceLast;
+    }
+    this.save();
+    this.render();
+  }
+
+  formatDuration(ms) {
+    const minutes = Math.floor(ms / 60000);
+    const hours = Math.floor(minutes / 60);
+    const mins = minutes % 60;
+    if (hours > 0) {
+      return `${hours}h ${mins}m`;
+    }
+    return `${mins}m`;
+  }
+
+  save() {
+    this.db.set('tasks', this.tasks);
+    this.db.set('lastCompletedTime', this.lastCompletedTime);
+  }
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  new TodoApp();
+});


### PR DESCRIPTION
## Summary
- convert todo list into floating window with toggle
- allow marking tasks complete and record completion time
- highlight priorities with distinct colors
- enable scrolling within the floating todo window for long lists

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689b5e14005c8322bd54c4075527c817