### PR TITLE
Add modal editor for stages and study templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ This is a basic HTML starter project you can build on however you like. No need 
 * Cuando la pestaña del navegador queda oculta, un pequeño overlay muestra la etapa actual y el tiempo restante.
 * Si el asistente estaba oculto, se mostrará temporalmente para anunciar la etapa.
 * Lista de tareas en ventana flotante con fecha y prioridad. Las tareas pueden arrastrarse, ordenarse por fecha o prioridad y marcarse como completadas, registrando la hora de finalización. También es posible ordenarlas mediante botones. Las prioridades se muestran con colores distintivos y la ventana permite desplazarse para manejar listas largas.
+* Edición de etapas desde un modal propio que permite cambiar nombre y duración, además de añadir nuevas etapas.
+* Plantillas de estudio populares preinstaladas (Pomodoro 25/5, 30/5, 50/10 y sesiones de redacción) para configurar el temporizador rápidamente.
 
 ## Overlay flotante
 

--- a/index.html
+++ b/index.html
@@ -264,6 +264,32 @@
     </div>
   </div>
 
+  <!-- Stage Modal -->
+  <div class="modal fade" id="stage-modal" tabindex="-1" aria-hidden="true">
+    <div class="modal-dialog">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title">Etapa</h5>
+          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+        </div>
+        <div class="modal-body">
+          <div class="mb-3">
+            <label for="stage-label" class="form-label">Nombre</label>
+            <input type="text" id="stage-label" class="form-control" required>
+          </div>
+          <div class="mb-3">
+            <label for="stage-duration" class="form-label">Duración (minutos)</label>
+            <input type="number" id="stage-duration" class="form-control" min="0" required>
+          </div>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancelar</button>
+          <button type="button" id="stage-save-btn" class="btn btn-primary">Guardar</button>
+        </div>
+      </div>
+    </div>
+  </div>
+
   <!-- Scripts -->
   <script src="html5up-massively/assets/js/jquery.min.js"></script>
   <script src="html5up-massively/assets/js/jquery.scrollex.min.js"></script>

--- a/style.css
+++ b/style.css
@@ -268,7 +268,7 @@ textarea {
 /* ==========================
    EDIT MODE
    ========================== */
-.delete-stage-btn {
+.delete-stage-btn { 
   position: absolute;
   top: 5px;
   right: 5px;
@@ -288,6 +288,22 @@ textarea {
 .edit-mode-only { display: none; }
 
 .edit-mode-active .delete-stage-btn { display: block; }
+.edit-stage-btn {
+  position: absolute;
+  top: 5px;
+  left: 5px;
+  background-color: var(--primary-color);
+  color: white;
+  border-radius: 50%;
+  width: 25px;
+  height: 25px;
+  padding: 0;
+  line-height: 25px;
+  text-align: center;
+  display: none;
+}
+.edit-stage-btn:hover { background-color: var(--primary-hover); }
+.edit-mode-active .edit-stage-btn { display: block; }
 .edit-mode-active #template-controls #edit-template-btn { display: none; }
 edit-mode-active #template-controls .edit-mode-only,
 .edit-mode-active #add-stage-container { display: inline-block; }


### PR DESCRIPTION
## Summary
- Allow editing and creating stages through a custom Bootstrap modal
- Add default templates for Pomodoro (25/5, 30/5, 50/10) and writing sessions
- Document new modal editor and templates

## Testing
- `npm test`
- `node --check timer.js` *(fails: Cannot use import statement outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_689e287280c48322b8c06d2dda33a751