### PR TITLE
feat: improve task management UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -135,9 +135,21 @@
           </div>
 
           <div id="todo-section" class="text-start">
-            <h2>Lista de Tareas</h2>
+            <div class="d-flex justify-content-between align-items-center">
+              <h2>Lista de Tareas</h2>
+              <button type="button" id="todo-close-btn" class="btn btn-sm btn-outline-secondary">Ocultar</button>
+            </div>
+            <div class="d-flex mb-2">
+              <input type="text" id="todo-search" class="form-control me-2" placeholder="Buscar..." />
+              <select id="todo-filter" class="form-select w-auto">
+                <option value="all">Todas</option>
+                <option value="high">Alta</option>
+                <option value="medium">Media</option>
+                <option value="low">Baja</option>
+              </select>
+            </div>
             <form id="todo-form" class="row g-2 align-items-center">
-              <div class="col-sm">
+              <div class="col-sm flex-grow-1">
                 <input type="text" id="todo-input" class="form-control" placeholder="Nueva tarea" />
               </div>
               <div class="col-auto">
@@ -159,6 +171,8 @@
               <button id="sort-priority" class="btn btn-sm btn-outline-secondary">Ordenar por Prioridad</button>
             </div>
             <ul id="todo-list" class="list-unstyled"></ul>
+            <h3 class="mt-3">Completadas</h3>
+            <ul id="completed-list" class="list-unstyled"></ul>
           </div>
 
           <div id="total-time" class="mb-3"><strong data-i18n="totalTime">Tiempo Total:</strong> <span>00:00</span></div>

--- a/style.css
+++ b/style.css
@@ -454,19 +454,17 @@ edit-mode-active #template-controls .edit-mode-only,
    TODO LIST (Floating panel)
    ========================== */
 #todo-section {
-  position: fixed;
-  top: 1rem;
-  right: 1rem;
-  width: 300px;
-  margin: 0;
+  position: static;
+  width: 100%;
+  max-width: 800px;
+  margin: 0 auto 1rem auto;
   background: var(--card-bg-color);
   border: 1px solid var(--border-color);
   border-radius: 8px;
   padding: 1rem;
-  box-shadow: 0 4px 8px rgba(0,0,0,0.2);
-  z-index: 1000;
-  max-height: 70vh;         /* Scroll interno */
-  overflow-y: auto;
+  box-shadow: none;
+  max-height: none;
+  overflow: visible;
 }
 #todo-list { list-style: none; padding: 0; }
 
@@ -512,21 +510,11 @@ edit-mode-active #template-controls .edit-mode-only,
 
 .todo-item .form-check-input { margin-right: 0.5rem; }
 
+#todo-input { width: 100%; }
+
 /* ==========================
    RESPONSIVE
    ========================== */
-@media (max-width: 992px) {
-  /* Integrar la lista en móviles/tablet */
-  #todo-section {
-    position: static;
-    width: 100%;
-    max-width: 800px;
-    margin: 0 auto 1rem auto;
-    box-shadow: none;
-    max-height: none;
-    overflow: visible;
-  }
-}
 
 @media (max-width: 768px) {
   .main-container { padding: 0 10px; }


### PR DESCRIPTION
## Summary
- reposition todo panel under timer and add collapse button
- fix task input width and add search and priority filter
- separate completed tasks and allow inline editing

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689e2c67bf608322bfd7647c4b22b074